### PR TITLE
Made screenProps function like native

### DIFF
--- a/src/createBrowserApp.js
+++ b/src/createBrowserApp.js
@@ -104,7 +104,7 @@ export default function createBrowserApp(App) {
       );
       return (
         <NavigationProvider value={this._navigation}>
-          <App navigation={this._navigation} />
+          <App {...this.props} navigation={this._navigation} />
         </NavigationProvider>
       );
     }


### PR DESCRIPTION
https://github.com/react-navigation/native/blob/a52a18cad62740780402ffa77d3dac83d57d2145/src/createAppContainer.js#L387
Without this, accessing `screenProps` won't work.