### PR TITLE
add anchorProps to <Link> so that attributes can be set to the enclosed anchor element

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -20,6 +20,7 @@ class LinkWithNavigation extends Component {
       routeKey,
       navigation,
       action,
+      anchorProps,
     } = this.props;
     const topNavigation = getTopNavigation(navigation);
     const topRouter = topNavigation.router;
@@ -62,6 +63,7 @@ class LinkWithNavigation extends Component {
           navigation.dispatch(navAction);
           e.preventDefault();
         }}
+        {...anchorProps}
       >
         {children}
       </a>


### PR DESCRIPTION
Hi,
First of all, thank you for the awesome package.

This PR is completely based on https://github.com/react-navigation/web/pull/12, so full credits to @clemMoine  . I needed to be able to set attributes to the anchor attributes (styling, data-, onclick, etc.), and created my own fork based on the feedback in #12 from @ericvicenti  . However, that PR has been inactive for a while. That's why I'm opening this PR in the hope it gets fixed sooner.  @clemMoine, if you rather want to update your PR, I'll delete this one.

Exmaple Usage:
```
                <Link
                  routeName="Docs"
                  navigation={navigation}
                  anchorProps={{
                    'data-testid': 'docs-link',
                    style: {
                       color: 'silver',
                    },
                  }}
                >
                  Docs
                </Link>
```

Best regards,
  Derk